### PR TITLE
Fixed home symlink

### DIFF
--- a/sdfsdk.rb
+++ b/sdfsdk.rb
@@ -18,7 +18,7 @@ class Sdfsdk < Formula
   def post_install
 
     # Install .clicache shortcut
-    system "ln", "-s", "~/.clicache", "#{bin}/.clicache"
+    system "ln", "-s", "#{ENV['HOME']}/.clicache", "#{bin}/.clicache"
 
   end
 


### PR DESCRIPTION
For some reason, `~` doesn't work to symlink the file. So, we need to use the absolutely value of the home path. 