### PR TITLE
Bump Java dependency version

### DIFF
--- a/sdfsdk.rb
+++ b/sdfsdk.rb
@@ -6,7 +6,7 @@ class Sdfsdk < Formula
   version "20.2.0"
 
   # Resolve cask dependencies
-  depends_on :java => "1.8"
+  depends_on :java => "11.0"
 
   def install
 


### PR DESCRIPTION
If you try to run 2020.2 sdfcli with java version 1.8 you will get this error `Your Java version is not compatible with SDF CLI. Install JRE version 11.`

I'm not 100% sure if this is the correct syntax for the formula (the cask I updated java from is called `java11` not `java`) so correct me if I'm wrong but I know you need java 11 here.